### PR TITLE
Dp modsplan talk corrections

### DIFF
--- a/_posts/2014-10-12-october-meetup.markdown
+++ b/_posts/2014-10-12-october-meetup.markdown
@@ -66,7 +66,7 @@ If [Django][Django] is your thing, we have a talk about integrating
 talk exploring some more advanced usage of [requests][requests]. So if web 
 development or API consumption are your thing, be sure to join us.
 
-[modsplan]: https://github.com/davipo/modsplan-compiler
+[modsplan]: http://modsplan.com/
 [BNF]: http://en.wikipedia.org/wiki/Backus%E2%80%93Naur_Form
 [Django]: https://www.djangoproject.com/
 [angjs]: https://angularjs.org/


### PR DESCRIPTION
Here are a few corrections to the Modsplan talk writeup, are they acceptable? You could spell it ModSPLan (not ModSpLan), but Modsplan is easier. Better to link to the modsplan.com website, which is more informative than the GitHub repo. (The link to the repo is on the website.) Thanks for the writeup!
