### PR TITLE
Use Kramdown not Redcarpet for markdown rendering.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 name: Madison Python Users' Group
-markdown: redcarpet
 highlighter: pygments
 
 authors:


### PR DESCRIPTION
Remove the markdown setting to use redcarpet per github's decision to stop supporting redcarpet use on github pages.
